### PR TITLE
Implements routing based on roles

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './App.css';
 import Layout from './ReactUI/Layout/Layout';
+import {useSelector} from "react-redux";
 
 import RenderRoutes from "./containers/Routes/Routes"
 import routes from "./containers/Routes/RouteDefs";
@@ -12,13 +13,16 @@ import {faCaretDown, faCheck} from '@fortawesome/free-solid-svg-icons'
 
 library.add(faCaretDown, faCheck);
 
-function App() {
-  return (
-    <div className="App">
-      <Layout>
+//function App() {
+const App = () => {
+
+  const user = useSelector(state => state.authenticationReducer.token_data);
+  
+  return (<div className="App">
+      <Layout user={user}>
         {/* <Authenticator> */}
         {/* Render the content using routes to determine components */}
-        <RenderRoutes routes={routes} handle404={true}/>
+        <RenderRoutes routes={routes} handle404={true} user={user}/>
         {/* </Authenticator> */}
       </Layout>
     </div>

--- a/src/ReactUI/Header/Header.js
+++ b/src/ReactUI/Header/Header.js
@@ -5,17 +5,15 @@ import RenderRoutes from "../../containers/Routes/Routes";
 import {bannerRoutes} from "../../containers/Routes/RouteDefs";
 import apiPaths from "../../store/paths";
 
-const Header = () => {
+const Header = (props) => {
 
   const auth = useSelector(state => state.authenticationReducer);
 
-  const user = auth.token_data === null ?  "" : auth.token_data.email
-
   return (
     <header className={"bg-app-primary"} >
-      <HeaderNavbar authenticated={auth.authenticated} user={user}/>
+      <HeaderNavbar authenticated={auth.authenticated} user={props.user} />
       {/* Render the banner by using routes */}
-      <RenderRoutes routes={bannerRoutes}/>
+      <RenderRoutes routes={bannerRoutes} user={props.user}/>
     </header>
   );
 }

--- a/src/ReactUI/Layout/Layout.js
+++ b/src/ReactUI/Layout/Layout.js
@@ -7,7 +7,7 @@ import AlertWindow from "../AlertWindow/AlertWindow";
 
 const Layout = (props) => (
   <Aux>
-    <Header/>
+    <Header user={props.user} />
     <main>
       <Container className={"h-100 mt-2"}>
         <AlertWindow/>

--- a/src/ReactUI/Page403/Page403.js
+++ b/src/ReactUI/Page403/Page403.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const page403 = React.memo(() => {
+  return (
+    <h1>403</h1>
+  );
+});
+
+export default page403;

--- a/src/containers/Authentication/Authenticator.js
+++ b/src/containers/Authentication/Authenticator.js
@@ -4,6 +4,7 @@ import Login from "../Authentication/Login";
 import {refreshToken} from "../../store/actions/";
 import axios from "../../services/axios/axios";
 import {loadUser} from "../../store/actions/";
+import Page403 from "../../ReactUI/Page403/Page403";
 
 const Authenticator = (props) => {
 
@@ -23,14 +24,22 @@ const Authenticator = (props) => {
         },
           error => Promise.reject(error)
       );
+      console.log(tokenInterceptor);
       dispatch(loadUser(auth.token_data.iri));
     } else {
-      axios.interceptors.request.eject(0);
       dispatch(refreshToken());
     }
+    return axios.interceptors.request.eject(tokenInterceptor);
   }, [dispatch, auth.authenticated, auth.token])
 
-  return auth.authenticated ? props.children : (form.hidden ? "" : <Login />);
+if(props.access) {
+  return props.children
+}
+else if (auth.authenticated) {
+  return <Page403 />
+}
+else
+  return form.hidden ? "" : <Login />;
 }
 
 export default Authenticator;

--- a/src/containers/Booking/BookingOwnerSelect.js
+++ b/src/containers/Booking/BookingOwnerSelect.js
@@ -24,7 +24,6 @@ const BookingOwnerSelect = (props) => {
   }, [dispatch, user.iri]);
 
   const handleSelect = (value) => {
-    console.log(value);
     dispatch(setOwner(value))
   }
 

--- a/src/containers/Navbars/HeaderNavbar.js
+++ b/src/containers/Navbars/HeaderNavbar.js
@@ -5,6 +5,7 @@ import {NavLink} from "react-router-dom";
 import {DisplayRouteNav} from "../../containers/Routes/Routes";
 import {headerRoutes} from "../../containers/Routes/RouteDefs";
 import LoginLink from './LoginLink';
+import { linkByRole } from '../../services/funcs/funcs';
 
 
 // We can use the 'as' prop to render Nav.Link as a react-router-dom NavLink.
@@ -16,10 +17,10 @@ const headerNavbar = React.memo((props) => (
       <Navbar.Toggle aria-controls="basic-navbar-nav"/>
       <Navbar.Collapse id="basic-navbar-nav">
         <Nav className="mr-auto">
-          <DisplayRouteNav routes={headerRoutes}/>
+          <DisplayRouteNav routes={headerRoutes.filter(route => linkByRole(route, props.user.roles))}/>
         </Nav>
         <Nav>
-          <LoginLink authenticated={props.authenticated} user={props.user}/>
+          <LoginLink authenticated={props.authenticated} user={props.user.email}/>
         </Nav>
       </Navbar.Collapse>
     </Navbar>

--- a/src/containers/Routes/RouteDefs.js
+++ b/src/containers/Routes/RouteDefs.js
@@ -23,6 +23,7 @@ const headerRoutes = [
     exact: true,
     component: Page,
     auth: false,
+    roles: ['IS_AUTHENTICATED_ANONYMOUSLY', 'ROLE_USER'],
     props:
       {
         apiUrl: "pages/2"
@@ -35,6 +36,7 @@ const headerRoutes = [
     exact: true,
     component: Page,
     auth: false,
+    roles: ['IS_AUTHENTICATED_ANONYMOUSLY', 'ROLE_USER'],
     props:
       {
         apiUrl: "pages/1"
@@ -47,6 +49,7 @@ const headerRoutes = [
     exact: true,
     component: Contact,
     auth: false,
+    roles: ['IS_AUTHENTICATED_ANONYMOUSLY', 'ROLE_USER'],
   },
   {
     path: "/register",
@@ -55,6 +58,7 @@ const headerRoutes = [
     exact: true,
     component: UserRegister,
     auth: false,
+    roles: ['IS_AUTHENTICATED_ANONYMOUSLY'],
   },
   
   
@@ -68,6 +72,7 @@ const footerRoutes = [
     exact: true,
     component: Page,
     auth: false,
+    roles: ['IS_AUTHENTICATED_ANONYMOUSLY', 'ROLE_USER'],
     props:
       {
         apiUrl: "pages/3"
@@ -80,6 +85,7 @@ const footerRoutes = [
     exact: true,
     component: Page,
     auth: false,
+    roles: ['IS_AUTHENTICATED_ANONYMOUSLY', 'ROLE_USER'],
     props:
       {
         apiUrl: "pages/4"
@@ -91,7 +97,9 @@ const footerRoutes = [
     title: "Members' Login",
     exact: true,
     component: Landing,
-    auth: true,
+    roles: ['ROLE_USER'],
+    forceLink: true,
+    auth: true
   },
 ];
 
@@ -102,6 +110,7 @@ const otherRoutes = [
     title: "Event",
     component: EventPage,
     auth: true,
+    roles: ['ROLE_USER']
   },
   {
     path: "/logout",
@@ -109,20 +118,23 @@ const otherRoutes = [
     title: "Log Out",
     exact: true,
     component: Logout,
+    roles: ['IS_AUTHENTICATED_ANONYMOUSLY', 'ROLE_USER'],
   },
   {
     path: "/forgot-password",
     key: "APP_FORGOT_PASSWORD",
     title: "Password Reset",
     exact: true,
-    component: PasswordResetRequest
+    component: PasswordResetRequest,
+    roles: ['IS_AUTHENTICATED_ANONYMOUSLY'],
   },
   {
     path: "/forgot-password/:token",
     key: "APP_FORGOT_PASSWORD_SUBMIT",
     title: "Password Reset",
     exact: true,
-    component: PasswordResetSubmit
+    component: PasswordResetSubmit,
+    roles: ['IS_AUTHENTICATED_ANONYMOUSLY'],
   },
   {
     path: "/myaccount/",
@@ -131,6 +143,7 @@ const otherRoutes = [
     component: UserEdit,
     exact: true,
     auth: true,
+    roles: ['ROLE_USER']
   },
   // {
   //   path: "/users/:id",
@@ -154,6 +167,7 @@ const routes = [
     component: RenderRoutes,
     routes: headerRoutes.concat(footerRoutes).concat(otherRoutes),
     auth: false,
+    roles: ['IS_AUTHENTICATED_ANONYMOUSLY', 'ROLE_USER'],
   },
 
 ];
@@ -165,6 +179,7 @@ const bannerRoutes = [
     exact: true,
     component: Banner,
     auth: false,
+    roles: ['IS_AUTHENTICATED_ANONYMOUSLY', 'ROLE_USER'],
   }
 ];
 

--- a/src/containers/Routes/Routes.js
+++ b/src/containers/Routes/Routes.js
@@ -8,6 +8,7 @@ import Page404 from "../../ReactUI/Page404/Page404";
 import * as actionTypes from "../../store/actions/actionsTypes";
 import {useDispatch} from "react-redux";
 import Authenticator from "../Authentication/Authenticator";
+import { accessByRole } from "../../services/funcs/funcs";
 
 /**
  *  Functions to render routers and children
@@ -36,7 +37,7 @@ const RenderRoutes = React.memo(
     return (
       <Switch>
         {props.routes.map((route) => {
-          return <RouteWithSubRoutes key={route.key} {...route} handle404={props.handle404}/>;
+          return <RouteWithSubRoutes key={route.key} {...route} handle404={props.handle404} user={props.user}/>;
         })}
         {page404}
       </Switch>
@@ -54,20 +55,21 @@ const RouteWithSubRoutes = React.memo(
    * @param {PropsWithChildren} route
    * @returns {JSX.Element}
    */
-  (route) => {
-    // Return the title and a route to the path, whether it's exact, and render the component specified.
+  (props) => {
+
     let routeComponent = <Route
-      path={route.path}
-      exact={route.exact}
-      render={props => <route.component {...props} {...route.props} routes={route.routes}
-                                        handle404={route.handle404}/>}
+      path={props.path}
+      exact={props.exact}
+      render={rprops => <props.component {...rprops} {...props.props} routes={props.routes} user={props.user}
+                                        handle404={props.handle404}/>}
     />
 
-    routeComponent = route.auth ? <Authenticator>{routeComponent}</Authenticator> : routeComponent;
+    //routeComponent = route.auth ? <Authenticator>{routeComponent}</Authenticator> : routeComponent;
+    routeComponent = <Authenticator access={accessByRole(props, props.user.roles)}>{routeComponent}</Authenticator>
     return (
       <Aux>
         {/* Only render the TitleComponent if route.title is set */}
-        <TitleComponent title={route.title} show={route.title}/>
+        <TitleComponent title={props.title} show={props.title}/>
         { routeComponent }
       </Aux>
     );

--- a/src/containers/TypeAhead/EntityTypeAhead.js
+++ b/src/containers/TypeAhead/EntityTypeAhead.js
@@ -35,7 +35,6 @@ const EntityTypeAhead = (props) => {
 
     const path = apiPaths[props.type].GET_COLLECTION + "?name=" + query.toLowerCase();
     axios.get(path).then((response) => {
-      console.log(response.data);
       setOptions(response.data['hydra:member']);
     })
     .finally(
@@ -50,7 +49,6 @@ const EntityTypeAhead = (props) => {
     // If value, then change
 
     if(props.handleSelect !== undefined && value[0] !== undefined) {
-      console.log(value[0]['@id']);
       props.handleSelect(value[0]['@id'], props.index);
     } 
   }

--- a/src/containers/TypeAhead/UserTypeAhead.js
+++ b/src/containers/TypeAhead/UserTypeAhead.js
@@ -35,7 +35,6 @@ const UserTypeAhead = (props) => {
 
     const path = apiPaths.user.GET_COLLECTION + "?name=" + query.toLowerCase();
     axios.get(path).then((response) => {
-      console.log(response.data);
       setOptions(response.data['hydra:member']);
     })
     .finally(

--- a/src/services/funcs/funcs.js
+++ b/src/services/funcs/funcs.js
@@ -18,3 +18,17 @@ export const strToDate = (item, el) => {
   }
   return item;
 }
+
+/**
+ * Returns true if the route contains a role that is in userRoles
+ * @param {obj} route 
+ * @param {[string]} userRoles 
+ * @returns {boolean}
+ */
+export const accessByRole = (route, userRoles) => {
+  return route.roles.filter(role => userRoles.includes(role)).length > 0;
+}
+
+export const linkByRole = (route, userRoles) => {
+  return route.forceLink ? true: accessByRole(route, userRoles);
+  }

--- a/src/store/helpers/formActions.js
+++ b/src/store/helpers/formActions.js
@@ -71,11 +71,9 @@ export const clearForm = (formName) => {
 
 
 export const submitForm = (formName, data, id = null, location = null) => dispatch => {
-  console.log(data);
   dispatch(setFormLocked(formName, true, id));
   const apiPath = (location === null) ? apiPaths[formName].POST : location;
   const apiMethod = (location === null) ? 'post':'patch';
-  console.log(apiPath);
 
   axios[apiMethod](apiPath, JSON.stringify(data))
   .then((response) => dispatch([

--- a/src/store/reducers/authentication/authentication.js
+++ b/src/store/reducers/authentication/authentication.js
@@ -5,7 +5,7 @@ import jwtDecode from "jwt-decode";
 const initialAuthState = {
   authenticated: false,
   token: null,
-  token_data: null,
+  token_data: {roles: ['IS_AUTHENTICATED_ANONYMOUSLY']},
   user: null
 }
 


### PR DESCRIPTION
Loads user as prop in <App> and then passes down to children.  On routes, prop.user.roles are used to display links and provide authorisation based on route.roles.  This removes the need for route.auth.
