### PR TITLE
Fixed event ticket query to show the correct event

### DIFF
--- a/src/containers/Event/EventTickets.js
+++ b/src/containers/Event/EventTickets.js
@@ -18,8 +18,10 @@ const EventTickets = (props) => {
   // Remove tickets that are not for Symposium or Dinner (ie 'membership' tickets)
   const tickets = ticketsState.filter(ticket => ticket.fields.ticketType.symposium || ticket.fields.ticketType.dinner)
 
+  console.log(authenticationState.token_data.iri);
+
   useEffect(() => {
-    dispatch(loadEventTickets(authenticationState.token_data.iri));
+    dispatch(loadEventTickets(props.id, authenticationState.token_data.iri));
   }, [dispatch]);
 
   const rows = tickets.map(ticket => (

--- a/src/store/actions/ticket.js
+++ b/src/store/actions/ticket.js
@@ -26,9 +26,9 @@ export const loadTickets = (event, owner = null, typeAsString = true) => dispatc
   });
 }
 
-export const loadEventTickets = (owner = null) => dispatch => {
+export const loadEventTickets = (eventid, owner = null) => dispatch => {
   const query = (owner !== null) ? "?owner=" + owner : "";
-  axios.get('/events/1/tickets' + query).then((response) => {
+  axios.get("/events/" + eventid + "/tickets" + query).then((response) => {
     const data = response.data['hydra:member'];
     
     return dispatch([resetTickets(), addTickets(data, false)]);


### PR DESCRIPTION
This fixed a bug where the tickets for /events/1 was always shown, regardless of the event.